### PR TITLE
Add rejectable type + fromRejectable function

### DIFF
--- a/src/Promise.js
+++ b/src/Promise.js
@@ -108,6 +108,10 @@ function $$catch(promise, callback) {
             });
 }
 
+function fromRejectable(promise, successCb, errCb) {
+  return $$catch(_then(promise, successCb), errCb);
+}
+
 function resolve(prim) {
   return _resolve(prim);
 }
@@ -126,6 +130,7 @@ function flatThen(prim, prim$1) {
 
 exports.JsError = JsError;
 exports.resolve = resolve;
+exports.fromRejectable = fromRejectable;
 exports.make = make;
 exports.$$then = $$then;
 exports.$$catch = $$catch;

--- a/src/Promise.res
+++ b/src/Promise.res
@@ -1,8 +1,6 @@
 type t<+'a> = Js.Promise.t<'a>
+type rejectable<+'a>
 
-// Will eventually be removed when Js.Exn.Error
-// can be constructed in userspace
-// See:
 exception JsError(Js.Exn.t)
 external unsafeToJsExn: exn => Js.Exn.t = "%identity"
 
@@ -68,7 +66,7 @@ external flatThen: (t<'a>, 'a => t<'b>) => t<'b> = "_flatThen"
 external then: (t<'a>, 'a => 'b) => t<'b> = "_then"
 
 @bs.scope("Promise") @bs.val
-external reject: exn => t<_> = "reject"
+external reject: exn => rejectable<_> = "reject"
 
 @bs.scope("Promise") @bs.val
 external jsAll: 'a => 'b = "all"
@@ -101,6 +99,12 @@ let catch = (promise, callback) => {
     }
     callback(v)
   })
+}
+
+external unsafeFromRejectable: rejectable<'a> => t<'a> = "%identity"
+
+let fromRejectable = (promise, successCb, errCb) => {
+  promise->unsafeFromRejectable->then(successCb)->catch(errCb)
 }
 
 @bs.scope("Promise") @bs.val

--- a/src/Promise.resi
+++ b/src/Promise.resi
@@ -1,23 +1,26 @@
 type t<+'a> = Js.Promise.t<'a>
+type rejectable<+'a>
 
 // Not a fan of this extra exception
 // ideally we'd be able to create a Js.Exn.Error
 // value instead
 //
-// Created a PR for this
+// Created a PR for this (got merged already)
 // https://github.com/rescript-lang/rescript-compiler/pull/4905
 exception JsError(Js.Exn.t)
 
 let resolve: 'a => t<'a>
 
+let fromRejectable: (rejectable<'a>, 'a => 'b, exn => 'b) => t<'b>
+
 @bs.scope("Promise") @bs.val
-external reject: exn => t<_> = "reject"
+external reject: exn => rejectable<_> = "reject"
 
 let make: (((. 'a) => unit, (. 'e) => unit) => unit) => t<'a>
 
 let then: (t<'a>, 'a => 'b) => t<'b>
 
-let catch: (t<'a>,  (exn) => 'b) => t<'b>
+let catch: (t<'a>, exn => 'b) => t<'b>
 
 let flatThen: (t<'a>, 'a => t<'b>) => t<'b>
 

--- a/tests/PromiseTest.js
+++ b/tests/PromiseTest.js
@@ -76,16 +76,18 @@ var ThenChaining = {
 };
 
 function testExnRejection(param) {
-  $$Promise.$$catch(Promise.reject({
+  $$Promise.fromRejectable(Promise.reject({
             RE_EXN_ID: TestError,
             _1: "oops"
-          }), (function (e) {
+          }), (function (param) {
+          
+        }), (function (e) {
           return Test.run([
                       [
                         "PromiseTest.res",
-                        99,
-                        26,
-                        30
+                        100,
+                        28,
+                        32
                       ],
                       "Expect rejection to contain a TestError"
                     ], e, equal, {
@@ -114,14 +116,16 @@ var asyncParseFail = (function() {
   });
 
 function testExternalPromiseThrow(param) {
-  return $$Promise.$$catch(Curry._1(asyncParseFail, undefined), (function (e) {
+  return $$Promise.fromRejectable(Curry._1(asyncParseFail, undefined), (function (param) {
+                
+              }), (function (e) {
                 var success = e.RE_EXN_ID === $$Promise.JsError ? Caml_obj.caml_equal(e._1.message, "Unexpected token . in JSON at position 1") : false;
                 return Test.run([
                             [
                               "PromiseTest.res",
-                              130,
-                              26,
-                              76
+                              135,
+                              21,
+                              71
                             ],
                             "Should be a parser error with Unexpected token ."
                           ], success, equal, true);
@@ -140,7 +144,7 @@ function testExnThrow(param) {
                 return Test.run([
                             [
                               "PromiseTest.res",
-                              148,
+                              158,
                               26,
                               49
                             ],
@@ -157,7 +161,7 @@ function testRaiseErrorThrow(param) {
                 return Test.run([
                             [
                               "PromiseTest.res",
-                              170,
+                              180,
                               26,
                               51
                             ],
@@ -168,21 +172,34 @@ function testRaiseErrorThrow(param) {
 
 function thenAfterCatch(param) {
   return $$Promise.$$then($$Promise.$$catch($$Promise.flatThen($$Promise.resolve(undefined), (function (param) {
-                        return Promise.reject({
-                                    RE_EXN_ID: TestError,
-                                    _1: "some rejected value"
-                                  });
-                      })), (function (e) {
-                    if (e.RE_EXN_ID === TestError && e._1 === "some rejected value") {
-                      return "success";
-                    } else {
-                      return "not a test error";
-                    }
+                        return $$Promise.fromRejectable(Promise.reject({
+                                        RE_EXN_ID: TestError,
+                                        _1: "some rejected value"
+                                      }), (function (param) {
+                                      return "shouldn't not resolve";
+                                    }), (function (e) {
+                                      if (e.RE_EXN_ID === TestError && e._1 === "some rejected value") {
+                                        return "success";
+                                      } else {
+                                        return "not a test error";
+                                      }
+                                    }));
+                      })), (function (param) {
+                    Test.run([
+                          [
+                            "PromiseTest.res",
+                            203,
+                            26,
+                            59
+                          ],
+                          "catch should not be called here"
+                        ], false, equal, true);
+                    return "unreachable";
                   })), (function (msg) {
                 return Test.run([
                             [
                               "PromiseTest.res",
-                              192,
+                              207,
                               26,
                               45
                             ],
@@ -249,7 +266,7 @@ function testParallel(param) {
                 return Test.run([
                             [
                               "PromiseTest.res",
-                              225,
+                              240,
                               26,
                               55
                             ],
@@ -276,7 +293,7 @@ function testRace(param) {
                 return Test.run([
                             [
                               "PromiseTest.res",
-                              243,
+                              258,
                               26,
                               44
                             ],


### PR DESCRIPTION
This is an experiment for a denotion of "rejectable promises".

**Example:**

```rescript
@val external queryUser: string => Promise.rejectable<string> = "API.queryUser"

queryUser("pat")->Promise.fromRejectable(data => {
  Ok(data)
}, (e) => {
  switch(e) {
  | JsError(msg) =>
      let m = Js.Exn.message(e)->Belt.Option.getWithDefault("unknown JS error")
      Error(m)
  | _ => Error("unknown error")
  }
})
->Promise.then(r => {
  switch r {
  | Ok(data) => Js.log(data)
  | Error(_) => Js.log("no data")
  }
})
```